### PR TITLE
feat: add middleware support

### DIFF
--- a/docs/user-guide.md
+++ b/docs/user-guide.md
@@ -22,6 +22,9 @@ Basic usage:
   enabled `mock-server` generates a self signed certificate that your borswer
   needs to trust before being able to make API calls to the server. To trust the
   certificate, visit https://localhost:3456 and dismiss the security warning
+- `middleware`: path string to file which returns an array of express
+  middleware. Note, the path should be relative to the mock server root
+  directory
 
 ### Writing handler files
 

--- a/src/bin/index.js
+++ b/src/bin/index.js
@@ -43,6 +43,11 @@ const argv = yargs
         describe: "Require the given modules",
         type: "array"
     })
+    .option("middleware", {
+        default: null,
+        describe: "path to file which returns array of express middleware",
+        type: "string"
+    })
     .wrap(Math.min(120, yargs.terminalWidth()))
     .strict().argv;
 

--- a/src/getApp/getMiddleware.js
+++ b/src/getApp/getMiddleware.js
@@ -1,0 +1,11 @@
+const { join, resolve } = require("path");
+
+module.exports = function getMiddleware(options) {
+    const middlewarePath = join(resolve(options.root), options.middleware);
+    const middlewareExport = require(middlewarePath);
+    const middleware =
+        middlewareExport && middlewareExport.__esModule
+            ? middlewareExport.default
+            : middlewareExport;
+    return middleware(options);
+};

--- a/src/getApp/index.js
+++ b/src/getApp/index.js
@@ -7,6 +7,7 @@ const decache = require("decache");
 const express = require("express");
 
 const getRoutes = require("./getRoutes");
+const getMiddleware = require("./getMiddleware");
 
 function getRouter(root) {
     const router = express.Router();
@@ -46,6 +47,9 @@ module.exports = function getApp(options) {
         .use(bodyParser.raw({ limit: "1gb", type: "*/*" }))
         .use(cookieParser())
         .use(getRouter(root));
+    if (options.middleware) {
+        server.use(getMiddleware(options));
+    }
     if (serveConfig) {
         require("dotenv/config");
         server.get(


### PR DESCRIPTION
To support middleware, adding a cli option for the user to specify a middleware file which would return an array of middleware to include.